### PR TITLE
Improved PKGBUILD according to our standards

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,20 +1,19 @@
-# Maintainer: TWljaGFsIFMuIDxtaWNoYWxAZ2V0Y3J5c3QuYWw+         | base64 -d
-# Maintainer: TWF0dCBDLiA8bWF0dEBnZXRjcnlzdC5hbD4=             | base64 -d
-# Credit:     UGllcnJlIFNjaG1pdHogPHBpZXJyZUBhcmNobGludXguZGU+ | base64 -d
+# Maintainer:  echo -n 'TWF0dCBDLiA8bWF0dEBnZXRjcnlzdC5hbD4='     | base64 -d
+# Contributor: echo -n 'TWljaGFsIFMuIDxtaWNoYWxAZ2V0Y3J5c3QuYWw+' | base64 -d
+# Contributor: echo -n 'Um9iaW4gQy4gPHJjYW5kYXVAZ2V0Y3J5c3QuYWw+' | base64 -d
 
 pkgname=crystal-keyring
-pkgver=20220729
+pkgver=2022.10.12
 pkgrel=1
 pkgdesc='Crystal Linux PGP keyring'
 arch=('any')
 url="https://github.com/crystal-linux/${pkgname}"
 license=('GPL')
-install="$pkgname.install"
-makedepends=('make' 'git')
-source=("git+$url")
-sha256sums=('SKIP')
+install="${pkgname}.install"
+source=("${pkgname}-${pkgver}::${url}/archive/${pkgver}.tar.gz")
+sha256sums=('d7da9302c0404ef31d726d994d49c9e0df14d7c8248525658b152abdacd91535')
 
 package() {
-  cd "$srcdir/$pkgname"
-  make PREFIX=/usr DESTDIR="$pkgdir" install
+    cd "${srcdir}/${pkgname}-${pkgver}"
+    make PREFIX=/usr DESTDIR="${pkgdir}" install
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# pkgbuild.crystal-keyring
+# crystal-keyring
 PKGBUILD for crystal-keyring


### PR DESCRIPTION
Hi,

A round of improvements for the `crystal-keyring` PKGBUILD:

- Switched all vars to the `${vars}' format.
- Replaced source from `git` to archive release's. Changed the `pkgver` and added the integrity check accordingly.
- Dropped the unnecessary `git` make depend since source are not `git anymore`
- Dropped the unnecessary `make` make depend since it's a member of `base-devel` which should be assumed installed IMO (as the AUR does).